### PR TITLE
Add yaml support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: python
 env:
 - TOX_ENV=py26
 - TOX_ENV=py27
-# TODO: re-enable when bravado-core supports py3.x - https://github.com/Yelp/bravado-core/issues/10
-#- TOX_ENV=py33
-#- TOX_ENV=py34
+- TOX_ENV=py34
+- TOX_ENV=py27-pyramid15
 - TOX_ENV=docs
 - TOX_ENV=pep8
 install:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.2.3 (2016-02-09)
+++++++++++++++++++++++
+* Restore testing of py3x versions
+* Support pyramid 1.6 and beyond.
+* Support specification of routes using route_prefix
+
 2.2.2 (2015-10-12)
 ++++++++++++++++++++++
 * Upgrade to bravado-core 3.0.0, which includes a change in the way user-defined formats are registered.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -71,7 +71,7 @@ For each of the routes declared in your swagger.json, you need to add the route 
         # Additional routes go here
         #
         config.scan()
-        return config.make_wsgi_app()      
+        return config.make_wsgi_app()
 
 Accessing request data
 ----------------------
@@ -118,7 +118,6 @@ models defined in ``#/definitions`` as Python classes instead of dicts.
           }
         }
       }
-      ...
     }
 
 .. code-block:: python
@@ -143,5 +142,5 @@ Otherwise, models are represented as dicts.
 
 .. note::
 
-    Values in ``request.swagger_data`` are only available if 
+    Values in ``request.swagger_data`` are only available if
     ``pyramid_swawgger.enable_request_validation`` is enabled.

--- a/pyramid_swagger/__about__.py
+++ b/pyramid_swagger/__about__.py
@@ -13,7 +13,7 @@ __title__ = "pyramid_swagger"
 __summary__ = "Swagger tools for use in pyramid webapps"
 __uri__ = "https://github.com/striglia/pyramid_swagger"
 
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 
 __author__ = "Scott Triglia"
 __email__ = "scott.triglia@gmail.com"

--- a/pyramid_swagger/exceptions.py
+++ b/pyramid_swagger/exceptions.py
@@ -2,10 +2,10 @@
 import sys
 
 import six
-from pyramid.httpexceptions import HTTPClientError, HTTPInternalServerError
+from pyramid.httpexceptions import HTTPBadRequest, HTTPInternalServerError
 
 
-class RequestValidationError(HTTPClientError):
+class RequestValidationError(HTTPBadRequest):
     pass
 
 

--- a/pyramid_swagger/ingest.py
+++ b/pyramid_swagger/ingest.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import glob
 import os.path
+import yaml
 
 import simplejson
 from bravado_core.spec import Spec
@@ -168,11 +169,20 @@ def get_swagger_spec(settings):
     :rtype: :class:`bravado_core.spec.Spec`
     """
     schema_dir = settings.get('pyramid_swagger.schema_directory', 'api_docs/')
-    schema_path = os.path.join(schema_dir, 'swagger.json')
+    schema_filename = settings.get('pyramid_swagger.schema_file', 'swagger.json')
+    schema_path = os.path.join(schema_dir, schema_filename)
     schema_url = urlparse.urljoin('file:', os.path.abspath(schema_path))
 
-    with open(schema_path, 'r') as f:
-        spec_dict = simplejson.loads(f.read())
+    fname, ext = os.path.splitext(schema_filename)
+    ext = ext.lower()
+    if ext == '.json':
+        with open(schema_path, 'r') as f:
+            spec_dict = simplejson.loads(f.read())
+    elif ext in ('.yaml', '.yml'):
+        with open(schema_path, 'r') as f:
+            spec_dict = yaml.load(f)
+    else:
+        raise Exception("Unknown extension: %s" % ext)
 
     return Spec.from_dict(
         spec_dict,

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -117,11 +117,14 @@ def get_swagger_objects(settings, route_info, registry):
     schema12 = registry.settings['pyramid_swagger.schema12']
     schema20 = registry.settings['pyramid_swagger.schema20']
 
-    if (SWAGGER_20 in enabled_swagger_versions
-        and SWAGGER_12 in enabled_swagger_versions
-        and settings.prefer_20_routes
-        and route_info.get('route')
-            and route_info['route'].name not in settings.prefer_20_routes):
+    fallback_to_swagger12_route = (
+        SWAGGER_20 in enabled_swagger_versions and
+        SWAGGER_12 in enabled_swagger_versions and
+        settings.prefer_20_routes and
+        route_info.get('route') and
+        route_info['route'].name not in settings.prefer_20_routes
+    )
+    if fallback_to_swagger12_route:
         return settings.swagger12_handler, schema12
 
     if SWAGGER_20 in enabled_swagger_versions:

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -552,7 +552,10 @@ def get_op_for_request(request, route_info, spec):
     # pyramid.urldispath.Route
     route = route_info['route']
     if hasattr(route, 'path'):
-        op = spec.get_op_for_request(request.method, route.path)
+        route_path = route.path
+        if route_path[0] != '/':
+            route_path = '/' + route_path
+        op = spec.get_op_for_request(request.method, route_path)
         if op is not None:
             return op
     raise PathNotMatchedError(

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'bravado-core >= 3.0.2',
         'jsonschema',
-        'pyramid<1.6.0a',
+        'pyramid',
         'simplejson',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
         'jsonschema',
         'pyramid',
         'simplejson',
+        'pyyaml',
     ],
 )

--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -51,8 +51,12 @@ def main(global_config, **settings):
     config.add_route('post_with_form_params', '/post_with_form_params')
     config.add_route('post_with_file_upload', '/post_with_file_upload')
     config.add_route('sample_post', '/sample')
-    config.add_route('sample_header', '/sample/header')
+    config.include(include_samples, route_prefix='/sample')
     config.add_route('throw_400', '/throw_400')
 
     config.scan()
     return config.make_wsgi_app()
+
+
+def include_samples(config):
+    config.add_route('sample_header', '/header')

--- a/tests/acceptance/invalid_file_test.py
+++ b/tests/acceptance/invalid_file_test.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import base64
+
+import pytest
+from webtest import TestApp
+
+from .app import main
+from pyramid_swagger.tween import SwaggerFormat
+
+
+@pytest.fixture
+def settings():
+    dir_path = 'tests/sample_schemas/'
+    return {
+        'pyramid_swagger.schema_file': 'swagger.txt',
+        'pyramid_swagger.schema_directory': dir_path,
+        'pyramid_swagger.enable_request_validation': True,
+        'pyramid_swagger.enable_swagger_spec_validation': True,
+    }
+
+
+@pytest.fixture
+def yaml_app():
+    return SwaggerFormat(format='base64',
+                         to_wire=base64.b64encode,
+                         to_python=base64.b64decode,
+                         validate=base64.b64decode,
+                         description='base64')
+
+
+def test_invalid_file_extension(settings, yaml_app):
+    """Fixture for setting up a Swagger 2.0 version of the test testapp."""
+    settings['pyramid_swagger.swagger_versions'] = ['2.0']
+    settings['pyramid_swagger.user_formats'] = [yaml_app]
+
+    with pytest.raises(Exception):
+        TestApp(main({}, **settings))

--- a/tests/acceptance/yaml_test.py
+++ b/tests/acceptance/yaml_test.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import base64
+
+import pytest
+from webtest import TestApp
+
+from .app import main
+from pyramid_swagger.tween import SwaggerFormat
+
+
+@pytest.fixture
+def settings():
+    dir_path = 'tests/sample_schemas/yaml_app/'
+    return {
+        'pyramid_swagger.schema_file': 'swagger.yaml',
+        'pyramid_swagger.schema_directory': dir_path,
+        'pyramid_swagger.enable_request_validation': True,
+        'pyramid_swagger.enable_swagger_spec_validation': True,
+    }
+
+
+@pytest.fixture
+def yaml_app():
+    return SwaggerFormat(format='base64',
+                         to_wire=base64.b64encode,
+                         to_python=base64.b64decode,
+                         validate=base64.b64decode,
+                         description='base64')
+
+
+@pytest.fixture
+def testapp_with_base64(settings, yaml_app):
+    """Fixture for setting up a Swagger 2.0 version of the test testapp."""
+    settings['pyramid_swagger.swagger_versions'] = ['2.0']
+    settings['pyramid_swagger.user_formats'] = [yaml_app]
+    return TestApp(main({}, **settings))
+
+
+def test_user_format_happy_case(testapp_with_base64):
+    response = testapp_with_base64.get('/sample/path_arg1/resource',
+                                       params={'required_arg': 'MQ=='},)
+    assert response.status_code == 200
+
+
+def test_user_format_failure_case(testapp_with_base64):
+    # 'MQ' is not a valid base64 encoded string.
+    with pytest.raises(Exception):
+        testapp_with_base64.get('/sample/path_arg1/resource',
+                                params={'required_arg': 'MQ'},)

--- a/tests/sample_schemas/yaml_app/defs.yaml
+++ b/tests/sample_schemas/yaml_app/defs.yaml
@@ -1,0 +1,30 @@
+definitions:
+  standard_response:
+    type: "object"
+    required:
+      - "raw_response"
+      - "logging_info"
+    additionalProperties: false
+    properties:
+      raw_response:
+        type: "string"
+      logging_info:
+        type: "object"
+  body_model:
+    type: "object"
+    required:
+      - "foo"
+    additionalProperties: false
+    properties:
+      foo:
+        type: "string"
+      bar:
+        type: "string"
+  array_content_model:
+    required:
+      - "enum_value"
+    properties:
+      enum_value:
+        type: "string"
+        enum:
+          - "good_enum_value"

--- a/tests/sample_schemas/yaml_app/swagger.yaml
+++ b/tests/sample_schemas/yaml_app/swagger.yaml
@@ -1,0 +1,96 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Title was not specified",
+    "version": "0.1"
+  },
+  "produces": ["application/json"],
+  "paths": {
+    "/sample/{path_arg}/resource": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Return a standard_response",
+            "schema": {
+              "$ref": "#/definitions/standard_response"
+            }
+          }
+        },
+        "description": "",
+        "operationId": "standard",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "path_arg",
+            "required": true,
+            "type": "string",
+            "enum": ["path_arg1", "path_arg2"]
+          },
+          {
+            "in": "query",
+            "name": "required_arg",
+            "required": true,
+            "type": "string",
+            "format": "base64"
+          },
+          {
+            "in": "query",
+            "name": "optional_arg",
+            "required": false,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  },
+  "host": "localhost:9999",
+  "schemes": [
+    "http"
+  ],
+  "definitions": {
+    "standard_response": {
+      "type": "object",
+      "required": [
+        "raw_response",
+        "logging_info"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "raw_response": {
+          "type": "string"
+        },
+        "logging_info": {
+          "type": "object"
+        }
+      }
+    },
+    "body_model": {
+      "type": "object",
+      "required": [
+        "foo"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "string"
+        }
+      }
+    },
+    "array_content_model": {
+      "required": [
+        "enum_value"
+      ],
+      "properties": {
+        "enum_value": {
+          "type": "string",
+          "enum": [
+            "good_enum_value"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/sample_schemas/yaml_app/swagger.yaml
+++ b/tests/sample_schemas/yaml_app/swagger.yaml
@@ -1,96 +1,37 @@
-{
-  "swagger": "2.0",
-  "info": {
-    "title": "Title was not specified",
-    "version": "0.1"
-  },
-  "produces": ["application/json"],
-  "paths": {
-    "/sample/{path_arg}/resource": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Return a standard_response",
-            "schema": {
-              "$ref": "#/definitions/standard_response"
-            }
-          }
-        },
-        "description": "",
-        "operationId": "standard",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "path_arg",
-            "required": true,
-            "type": "string",
-            "enum": ["path_arg1", "path_arg2"]
-          },
-          {
-            "in": "query",
-            "name": "required_arg",
-            "required": true,
-            "type": "string",
-            "format": "base64"
-          },
-          {
-            "in": "query",
-            "name": "optional_arg",
-            "required": false,
-            "type": "string"
-          }
-        ]
-      }
-    }
-  },
-  "host": "localhost:9999",
-  "schemes": [
-    "http"
-  ],
-  "definitions": {
-    "standard_response": {
-      "type": "object",
-      "required": [
-        "raw_response",
-        "logging_info"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "raw_response": {
-          "type": "string"
-        },
-        "logging_info": {
-          "type": "object"
-        }
-      }
-    },
-    "body_model": {
-      "type": "object",
-      "required": [
-        "foo"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "foo": {
-          "type": "string"
-        },
-        "bar": {
-          "type": "string"
-        }
-      }
-    },
-    "array_content_model": {
-      "required": [
-        "enum_value"
-      ],
-      "properties": {
-        "enum_value": {
-          "type": "string",
-          "enum": [
-            "good_enum_value"
-          ]
-        }
-      }
-    }
-  }
-}
+---
+swagger: "2.0"
+info:
+  title: "Title was not specified"
+  version: "0.1"
+host: "localhost:9999"
+schemes:
+  - "http"
+produces:
+  - "application/json"
+paths:
+  "/sample/{path_arg}/resource":
+    get:
+      responses:
+        "200":
+          description: "Return a standard_response"
+          schema:
+            "$ref": "defs.yaml#/definitions/standard_response"
+      description: ""
+      operationId: "standard"
+      parameters:
+        - in: "path"
+          name: "path_arg"
+          required: true
+          type: "string"
+          enum:
+            - "path_arg1"
+            - "path_arg2"
+        - in: "query"
+          name: "required_arg"
+          required: true
+          type: "string"
+          format: "base64"
+        - in: "query"
+          name: "optional_arg"
+          required: false
+          type: "string"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # TODO: re-enable py33,py34 when bravado-core is py3x compatible - https://github.com/Yelp/bravado-core/issues/10
-envlist = py26,py27,py33,py34,pep8
+envlist = py26,py27,py33,py34,py35,{py27,py35}-pyramid15,pep8
 
 [testenv]
 deps =
@@ -9,6 +9,8 @@ deps =
     pytest
     ordereddict
     webtest
+    pyramid15: pyramid<=1.5.4
+
 commands =
     coverage run --source=pyramid_swagger/ --omit=pyramid_swagger/__about__.py -m pytest --capture=no --strict {posargs}
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-# TODO: re-enable py33,py34 when bravado-core is py3x compatible - https://github.com/Yelp/bravado-core/issues/10
 envlist = py26,py27,py33,py34,py35,{py27,py35}-pyramid15,pep8
 
 [testenv]


### PR DESCRIPTION
Two missing features I noticed when using with a yaml file that did header verification. I was trying to return a Response of 201 with a Location header set, no body, and these changes were required before things worked right.
